### PR TITLE
change main page share link to a router Link

### DIFF
--- a/src/ListPage.js
+++ b/src/ListPage.js
@@ -102,7 +102,7 @@ class ColButton extends Component {
           <div className="d-flex justify-content-between align-items-center">
             <div>
               <p style={{fontSize: '30px', marginBottom: 0}}>{this.props.groupName}</p>
-              <a href={this.props.groupLink}>{window.location.hostname + this.props.groupLink}</a>
+              <Link to={this.props.groupLink}>{window.location.hostname + this.props.groupLink}</Link>
             </div>
             <Button variant="primary" as={Link} to={this.props.groupLink}>Open List</Button>
           </div>


### PR DESCRIPTION
small tweak to change the "share" link on the main page from an `<a>` tag to a router `<Link>` tag so the page doesn't reload if a user happens to click it