### PR TITLE
Animate routes in/out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4893,6 +4893,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -5321,6 +5330,7 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5352,6 +5362,12 @@
           "requires": {
             "to-regex-range": "^5.0.1"
           }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
         },
         "is-number": {
           "version": "7.0.0",
@@ -7716,6 +7732,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8026,6 +8048,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -9404,6 +9436,7 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -10522,6 +10555,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12898,6 +12937,7 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "4.3.0",
         "fs-extra": "^8.1.0",
+        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -12926,6 +12966,14 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "optional": true
+        }
       }
     },
     "react-transition-group": {
@@ -15217,6 +15265,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -15490,6 +15539,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-responsive": "^8.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
+    "react-transition-group": "^4.4.1",
     "styled-components": "^5.2.0",
     "whatwg-fetch": "^3.4.1"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import firebase from 'firebase/app';
 import AlertBar from './AlertBar';
 import ListDetailsPage from './ListDetailsPage';
 import Footer from './Footer';
+import { CSSTransition } from 'react-transition-group';
 
 class App extends Component {
   constructor(props) {
@@ -125,20 +126,37 @@ class App extends Component {
   };
 
   render() {
-    const renderListDetailsPage = routeParams => <ListDetailsPage {...routeParams} user={this.state.user} handleError={this.handleError} clearAlert={this.clearAlert} />;
-    const renderGroupsPage = routeParams => <ListPage {...routeParams} authReady={this.state.authReady} user={this.state.user} handleError={this.handleError} />;
     return (
       <Router>
         <Navbar user={this.state.user} handleSignOut={this.handleSignOut}
           handleSignUp={this.showSignUpModal} handleSignIn={this.showSignInModal} authReady={this.state.authReady} />
         <AlertBar alert={this.state.alert} />
         <Container className="mt-3 mb-3">
-          <Switch>
-            <Route exact path="/" render={renderGroupsPage} />
-            <Route path="/about" component={AboutPage} />
-            <Route path="/group/:groupid" render={renderListDetailsPage} />
-            <Redirect to="/" />
-          </Switch>
+          <Route exact path="/">
+            {routeParams => (
+              <CSSTransition in={routeParams.match != null} timeout={{enter: 600, exit: 300}} classNames="route" unmountOnExit>
+                <div>
+                  <ListPage {...routeParams} authReady={this.state.authReady} user={this.state.user} handleError={this.handleError} />
+                </div>
+              </CSSTransition>
+            )}
+          </Route>
+          <Route path="/about">
+            {({ match }) => (
+              <CSSTransition in={match != null} timeout={{enter: 600, exit: 300}} classNames="route" unmountOnExit>
+                <AboutPage />
+              </CSSTransition>
+            )}
+          </Route>
+          <Route path="/group/:groupid">
+            {routeParams => (
+              <CSSTransition in={routeParams.match != null} timeout={{enter: 600, exit: 300}} classNames="route" unmountOnExit>
+                <div>
+                  <ListDetailsPage {...routeParams} user={this.state.user} handleError={this.handleError} clearAlert={this.clearAlert} />
+                </div>
+              </CSSTransition>
+            )}
+          </Route>
         </Container>
         <Footer />
         <AuthModal onSubmit={this.handleSignUp} show={this.state.showSignUpModal} onHide={this.hideSignUpModal} title="Sign up!" buttonText="Sign up" />

--- a/src/IdeaGroup.js
+++ b/src/IdeaGroup.js
@@ -1,16 +1,18 @@
 import React, {Component} from 'react';
 import IdeaCard from './IdeaCard';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 class IdeaGroup extends Component {
   render() {
-    const ideaCards = this.props.ideas.map((idea, idx) => <IdeaCard key={idea.id} idea={idea} user={this.props.user}
-      handleRemove={this.props.handleRemove} adminUID={this.props.adminUID} gid={this.props.groupId}
-      className={parseInt(this.props.highlightIdx) === idx && 'highlight-card'} />);
+    const ideaCards = this.props.ideas.map((idea, idx) => <CSSTransition key={idea.id} timeout={500} classNames="idea-card">
+      <IdeaCard idea={idea} user={this.props.user} handleRemove={this.props.handleRemove}
+      adminUID={this.props.adminUID} gid={this.props.groupId}
+      className={parseInt(this.props.highlightIdx) === idx && 'highlight-card'} /></CSSTransition>);
     return (
       <>
         <h2>{this.props.title}</h2>
         { this.props.ideas.length === 0 ? <p>No ideas found... maybe try suggesting one?</p>
-                                        : <section className="idea-card-group">{ideaCards}</section> }
+                                        : <TransitionGroup className="idea-card-group">{ideaCards}</TransitionGroup> }
       </>
     );
   }

--- a/src/index.css
+++ b/src/index.css
@@ -148,6 +148,24 @@ a, .btn-link {
   max-width: 45%;
 }
 
+.idea-card-enter {
+  transform: scale(0);
+}
+
+.idea-card-enter-active {
+  transform: scale(1.0);
+  transition: transform 100ms ease-in;
+}
+
+.idea-card-exit {
+  transform: scale(1.2);
+}
+
+.idea-card-exit-active {
+  transform: scale(0);
+  transition: transform 100ms ease-in;
+}
+
 #root {
   min-height: 100vh;
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -168,6 +168,28 @@ a, .btn-link {
   transform: scale(0);
 }
 
+.route-enter {
+  transform: translateX(-100vw);
+}
+
+.route-enter-active {
+  transform: translateX(0);
+  transition: transform 300ms 300ms ease-out;
+}
+
+.route-exit {
+  transform: translateX(0);
+}
+
+.route-exit-active {
+  transform: translateX(100vw);
+  transition: transform 300ms ease-out;
+}
+
+body {
+  overflow-x: hidden;
+}
+
 #root {
   min-height: 100vh;
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -152,9 +152,12 @@ a, .btn-link {
   transform: scale(0);
 }
 
+.idea-card-enter-active, .idea-card-exit-active {
+  transition: transform 100ms ease-in;
+}
+
 .idea-card-enter-active {
   transform: scale(1.0);
-  transition: transform 100ms ease-in;
 }
 
 .idea-card-exit {
@@ -163,7 +166,6 @@ a, .btn-link {
 
 .idea-card-exit-active {
   transform: scale(0);
-  transition: transform 100ms ease-in;
 }
 
 #root {


### PR DESCRIPTION
building off of #6, adds animations to route transitions. there are a few issues with this:

- the `<Switch>` element from react-router was removed since it automatically hides non-matching routes, which would break exit animations
- the page looks a little jank due to the order of the elements and taking up space before they animate on. tricks like absolute positioning don't work due to the footer. it'd be nice if the in change could be delayed by 300ms (maybe a setTimeout? 🤔), or a slight style overhaul (fix positioning/flexbox of header/footer/main container content, or make non-animated content somehow 0 height)

![animated gif](https://i.imgur.com/wzHB9MP.gif)